### PR TITLE
[BFID-559] Fix WatchlistScreening webhook

### DIFF
--- a/lib/veriff/version.rb
+++ b/lib/veriff/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Veriff
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end

--- a/lib/veriff/webhooks/watchlist_screening.rb
+++ b/lib/veriff/webhooks/watchlist_screening.rb
@@ -6,7 +6,9 @@ module Veriff
       extend Webhook
 
       def initialize(body)
-        super(Parser.call(body, :json))
+        data_hash = Parser.call(body, :json)
+        data_hash.fetch(:attempt_id)
+        @data_hash = data_hash
       end
     end
   end

--- a/spec/veriff/webhooks/watchlist_screening_spec.rb
+++ b/spec/veriff/webhooks/watchlist_screening_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+RSpec.describe Veriff::Webhooks::WatchlistScreening do
+  describe 'initialization' do
+    subject(:model) { described_class.new(params) }
+
+    context 'with valid params' do
+      let(:params) { { "attempt_id": 1, "foo": "bar" }.to_json }
+
+      it 'can be initialized without id' do
+        expect { model }.not_to raise_error
+      end
+    end
+
+    context 'with invalid params' do
+      let(:params) { { "id": 1, "foo": "bar" }.to_json }
+
+      it 'cannot be initialized without attempt_id' do
+        expect { model }.to raise_error(KeyError, 'key not found: :attempt_id')
+      end
+    end
+  end
+
+  describe '#parse' do
+    subject(:parse) { described_class.parse(body, signature) }
+
+    let(:signature) { SecureRandom.uuid }
+    let(:body) do
+      {
+        "checkType": "updated_result",
+        "attemptId": "54233318-f81c-4ec4-8e4c-413168a3f5e6",
+        "vendorData": "12345678",
+        "matchStatus": "possible_match",
+        "searchTerm": {
+          "name": "Mirko Kokki",
+          "year": "1960"
+        },
+        "totalHits": 5,
+        "createdAt": "2021-06-02T11:04:00.287Z",
+        "hits": [
+          {
+            "matchedName": "Miro kokkino",
+            "countries": [
+              "Australia",
+              "Brazil"
+            ],
+            "dateOfBirth": "1963",
+            "dateOfDeath": nil,
+            "matchTypes": [
+              "name_fuzzy"
+            ],
+            "aka": [
+              "Mirkoni kokki",
+              "Mirkor Kokki"
+            ],
+            "associates": [
+              "Desmon Lamela",
+              "Fred Austin"
+            ],
+            "listingsRelatedToMatch": {
+              "warnings": [
+                {
+                  "sourceName": "FBI Most Wanted",
+                  "sourceUrl": "http://www.fbi.gov/wanted",
+                  "date": nil
+                }
+              ],
+              "sanctions": [
+                {
+                  "sourceName": "Argentina Ministerio de Relaciones Exteriores y Culto Sanciones de la ONU",
+                  "sourceUrl": "https://www.cancilleria.gob.ar/es/politica-exterior/seguridad-internacional/comite-de-sanciones",
+                  "date": nil
+                },
+                {
+                  "sourceName": "Argentina Public Registry of People and Entities linked to acts of Terrorism and Terrorism Financing",
+                  "sourceUrl": "https://repet.jus.gob.ar/#entidades",
+                  "date": nil
+                }
+              ],
+              "fitnessProbity": [
+                {
+                  "source_name": "United Kingdom Insolvency Service Disqualified Directors",
+                  "source_url": "https://www.insolvencydirect.bis.gov.uk/IESdatabase/viewdirectorsummary-new.asp"
+                }
+              ],
+              "pep": [
+                {
+                  "source_name": "United States Navy Leadership and Senior Military Officials",
+                  "source_url": "https://www.navy.mil/Leadership/Biographies/"
+                }
+              ],
+              "adverseMedia": [
+                {
+                  "date": "2020-09-23T00:00:00Z",
+                  "source_name": "SNA's Old Salt Award Passed to Adm. Davidson",
+                  "source_url": "https://www.marinelink.com/amp/news/snas-old-salt-award-passed-adm-davidson-443093"
+                }
+              ]
+            }
+          }
+        ]
+      }.to_json
+    end
+
+    before do
+      allow(Veriff).to receive(:validate_signature).with(body, signature).and_return(true)
+    end
+
+    it 'returns attempt id' do
+      expect(parse.attempt_id).to eq("54233318-f81c-4ec4-8e4c-413168a3f5e6")
+    end
+
+    it 'returns created at' do
+      expect(parse.created_at).to eq("2021-06-02T11:04:00.287Z")
+    end
+  end
+end


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Add here link to Jira, but let this not be the only content in this section -->
**[JIRA ticket](https://banktothefuture.atlassian.net/browse/BFID-559)**
Fix for `Veriff::Webhooks::WatchlistScreening` webhook. It failed initialization since the method `initialize` wasn't overridden properly.

## Description
<!--- Describe what you have done and why have you done it this way -->
- Override `Veriff::Webhooks::WatchlistScreening` webhook constructor
- Add Spec for `Veriff::Webhooks::WatchlistScreening` webhook

## Screenshots (if appropriate):

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added tests to cover my changes.
