### PR TITLE
Fixed veriff security

### DIFF
--- a/lib/veriff.rb
+++ b/lib/veriff.rb
@@ -22,6 +22,7 @@ require 'veriff/webhook'
 require 'veriff/webhooks/invalid_signature_error'
 require 'veriff/webhooks/event'
 require 'veriff/webhooks/decision'
+require 'veriff/webhooks/fullauto'
 require 'veriff/webhooks/watchlist_screening'
 
 module Veriff

--- a/lib/veriff.rb
+++ b/lib/veriff.rb
@@ -35,6 +35,7 @@ module Veriff
 
   headers(
     'CONTENT-TYPE' => 'application/json',
-    'X-AUTH-CLIENT' => -> { configuration.api_key }
+    'X-AUTH-CLIENT' => -> { configuration.api_key },
+    'X-HMAC-SIGNATURE' => ->(options) { generate_signature(options) }
   )
 end

--- a/lib/veriff.rb
+++ b/lib/veriff.rb
@@ -35,7 +35,6 @@ module Veriff
 
   headers(
     'CONTENT-TYPE' => 'application/json',
-    'X-AUTH-CLIENT' => -> { configuration.api_key },
-    'X-SIGNATURE' => ->(options) { generate_signature(options) }
+    'X-AUTH-CLIENT' => -> { configuration.api_key }
   )
 end

--- a/lib/veriff/model.rb
+++ b/lib/veriff/model.rb
@@ -2,8 +2,10 @@
 
 module Veriff
   class Model
+    attr_reader :data_hash
+
     def initialize(data_hash)
-      data_hash.fetch(:id)
+      data_hash.fetch(:id) { data_hash.fetch(:session_id) }
       @data_hash = data_hash
     end
 

--- a/lib/veriff/security.rb
+++ b/lib/veriff/security.rb
@@ -3,9 +3,8 @@
 module Veriff
   module Security
     def generate_signature(options)
-      Digest::SHA256.hexdigest(
-        "#{options[:signature] || options[:body]}#{configuration.api_secret}"
-      )
+      digest = OpenSSL::Digest.new('sha256')
+      OpenSSL::HMAC.hexdigest(digest, configuration.api_secret, options[:body])
     end
 
     def validate_signature(body, signature)

--- a/lib/veriff/version.rb
+++ b/lib/veriff/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Veriff
-  VERSION = '0.2.1'
+  VERSION = '0.2.2'
 end

--- a/lib/veriff/webhook.rb
+++ b/lib/veriff/webhook.rb
@@ -3,9 +3,9 @@
 module Veriff
   module Webhook
     def parse(body, signature)
-      return new(body) if Veriff::validate_signature(body, signature)
+      return new(body) if Veriff.validate_signature(body, signature)
 
-      raise Webhooks::InvalidSignatureError, 'Given signature does not match body and API Secret'
+      raise Webhooks::InvalidSignatureError, "Given signature #{signature} does not match body and API Secret"
     end
   end
 end

--- a/lib/veriff/webhooks/fullauto.rb
+++ b/lib/veriff/webhooks/fullauto.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Veriff
+  module Webhooks
+    class Fullauto < Model
+      extend Webhook
+
+      def initialize(body)
+        super(Parser.call(body, :json))
+      end
+
+      def data
+        @data ||= OpenStruct.new(@data_hash[:data])
+      end
+
+      def id
+        session_id
+      end
+
+      def verification
+        @verification ||= OpenStruct.new(data.verification)
+      end
+
+      def person
+        @person ||= OpenStruct.new(verification.person)
+      end
+
+      def document
+        @document ||= OpenStruct.new(verification.document)
+      end
+    end
+  end
+end

--- a/veriff.gemspec
+++ b/veriff.gemspec
@@ -7,16 +7,16 @@ require 'veriff/version'
 Gem::Specification.new do |spec|
   spec.name          = 'veriff'
   spec.version       = Veriff::VERSION
-  spec.authors       = ['Wojtek Widenka']
-  spec.email         = ['wojtek@codegarden.online']
+  spec.authors       = ['Wojtek Widenka', 'Sergei Tsõganov']
+  spec.email         = ['wojtek@codegarden.online', 'sergei.tsoganov@internet.ee']
 
   spec.summary       = 'Simple wrapper on Verff.com API'
   spec.description   = 'Simple wrapper on Verff.com API'
-  spec.homepage      = 'https://github.com/BankToTheFuture/veriff_ruby'
+  spec.homepage      = 'https://github.com/maricavor/veriff_ruby'
   spec.license       = 'MIT'
 
   spec.metadata['homepage_uri'] = spec.homepage
-  spec.metadata['source_code_uri'] = 'https://github.com/BankToTheFuture/veriff_ruby'
+  spec.metadata['source_code_uri'] = 'https://github.com/maricavor/veriff_ruby'
 
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
     `git ls-files -z`


### PR DESCRIPTION
- Renewed method for generating signature OpenSSL::HMAC.hexdigest. This method is used to compute a Hash-based Message Authentication Code (HMAC) using a specified hash function, in this case, SHA-256. HMAC involves both a secret key and the data/message. It provides both data integrity and authentication because it uses a secret key. 
- Removed legacy header from Veriff request